### PR TITLE
fix(composer.json): use macos compatible mkdir flag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         ],
         "post-root-package-install": [
             "mkdir data",
-            "mkdir --parent src/templates",
+            "mkdir -p src/templates",
             "mkdir tests"
         ],
         "post-create-project-cmd": [


### PR DESCRIPTION
--parent don't work on mac