### PR TITLE
fix: use the correct implementations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "phpolar/validators": "^1.1",
         "nyholm/psr7": "^1.7",
         "nyholm/psr7-server": "dev-master",
-        "phpolar/phpolar": "^2.0"
+        "phpolar/phpolar": "^2.0",
+        "phpolar/pure-php": "^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fe36d0afd2d24f979ebfd372162ca593",
+    "content-hash": "c3852c5e14832d377443d028f38b0351",
     "packages": [
         {
             "name": "nyholm/psr7",
@@ -598,6 +598,61 @@
                 "source": "https://github.com/phpolar/phpolar-storage/tree/1.2.1"
             },
             "time": "2023-04-30T17:33:59+00:00"
+        },
+        {
+            "name": "phpolar/pure-php",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpolar/pure-php.git",
+                "reference": "dfe17daaef109c6931d61f65c70b701a4a51479f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpolar/pure-php/zipball/dfe17daaef109c6931d61f65c70b701a4a51479f",
+                "reference": "dfe17daaef109c6931d61f65c70b701a4a51479f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phan/phan": "^5.4",
+                "php-coveralls/php-coveralls": "^2.5",
+                "phpmd/phpmd": "^2.13",
+                "phpstan/phpstan": "^1.9",
+                "phpunit/phpunit": "^10.0",
+                "squizlabs/php_codesniffer": "^3.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Phpolar\\PurePhp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Eric Fortmeyer",
+                    "email": "e.fortmeyer01@gmail.com"
+                }
+            ],
+            "description": "Pure PHP Templates",
+            "keywords": [
+                "php",
+                "template-engine",
+                "template-language",
+                "templates"
+            ],
+            "support": {
+                "issues": "https://github.com/phpolar/pure-php/issues",
+                "source": "https://github.com/phpolar/pure-php/tree/1.0.4"
+            },
+            "time": "2023-04-30T17:37:13+00:00"
         },
         {
             "name": "phpolar/storage-driver",

--- a/public/resources/css/overrides.css
+++ b/public/resources/css/overrides.css
@@ -1,4 +1,4 @@
 [data-style=danger] {
-  border-color: var(--del-color);
-  background-color: var(--del-color);
+  border-color: var(--pico-del-color);
+  background-color: var(--pico-del-color);
 }

--- a/src/config/dependencies/conf.d/http.php
+++ b/src/config/dependencies/conf.d/http.php
@@ -4,15 +4,13 @@ declare(strict_types=1);
 
 namespace Phpolar\MyApp;
 
-use Laminas\Diactoros\RequestFactory;
-use Laminas\Diactoros\ResponseFactory;
-use Laminas\Diactoros\StreamFactory;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 
+$psr17Factory = new \Nyholm\Psr7\Factory\Psr17Factory();
 return [
-    RequestFactoryInterface::class => static fn () => new RequestFactory(),
-    ResponseFactoryInterface::class => static fn () => new ResponseFactory,
-    StreamFactoryInterface::class => static fn () => new StreamFactory(),
+    RequestFactoryInterface::class => static fn () => $psr17Factory,
+    ResponseFactoryInterface::class => static fn () => $psr17Factory,
+    StreamFactoryInterface::class => static fn () => $psr17Factory,
 ];

--- a/src/config/dependencies/conf.d/templating.php
+++ b/src/config/dependencies/conf.d/templating.php
@@ -9,6 +9,8 @@ use Phpolar\PurePhp\Dispatcher;
 use Phpolar\PurePhp\StreamContentStrategy;
 use Phpolar\PurePhp\TemplateEngine;
 
+
+
 return [
     TemplateEngine::class => static fn () => new TemplateEngine(
         new StreamContentStrategy(),


### PR DESCRIPTION
Previously used implementations were left in the dependency injection configuration which caused errors.

Now using https://github.com/Nyholm/psr7 because it allows psr7 2.0. See https://github.com/php-fig/http-message/releases/tag/2.0