### PR TITLE
fix(public/index.php): move method call

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -76,6 +76,6 @@ $routes->add("POST", "/person/delete/{id}", new DeletePerson());
  * ==========================================================
  */
 $app = App::create($containerManager);
-$app->useRoutes($routes);
 // $app->useCsrfMiddleware();
+$app->useRoutes($routes);
 $app->receive($serverRequest);


### PR DESCRIPTION
The `useCsrfProtection` method needs to be called before `useRoutes` is called.

Closes #35