### PR TITLE
fix: use only one instance

### DIFF
--- a/src/config/dependencies/conf.d/http.php
+++ b/src/config/dependencies/conf.d/http.php
@@ -10,7 +10,7 @@ use Psr\Http\Message\StreamFactoryInterface;
 
 $psr17Factory = new \Nyholm\Psr7\Factory\Psr17Factory();
 return [
-    RequestFactoryInterface::class => static fn () => $psr17Factory,
-    ResponseFactoryInterface::class => static fn () => $psr17Factory,
-    StreamFactoryInterface::class => static fn () => $psr17Factory,
+    RequestFactoryInterface::class => $psr17Factory,
+    ResponseFactoryInterface::class => $psr17Factory,
+    StreamFactoryInterface::class => $psr17Factory,
 ];

--- a/src/config/dependencies/conf.d/storage.php
+++ b/src/config/dependencies/conf.d/storage.php
@@ -7,16 +7,13 @@ namespace Phpolar\MyApp;
 use Phpolar\CsvFileStorage\CsvFileStorage;
 use Phpolar\Example\Person;
 use Phpolar\Phpolar\Storage\AbstractStorage;
-use Psr\Container\ContainerInterface;
 
+const CSV_STORAGE = "data/example.csv";
 /**
  * This contains the services/dependencies required
  * by the PHPolar Microframework.
  */
 return [
-    "csv_storage" => "data/example.csv",
-    AbstractStorage::class => static fn (
-        ContainerInterface $container
-    ) => new CsvFileStorage($container->get("csv_storage")),
-    "PEOPLE_STORAGE" => static fn (ContainerInterface $container) => new CsvFileStorage($container->get("csv_storage"), Person::class),
+    AbstractStorage::class => new CsvFileStorage(CSV_STORAGE),
+    "PEOPLE_STORAGE" => new CsvFileStorage(CSV_STORAGE, Person::class),
 ];

--- a/src/config/dependencies/conf.d/templating.php
+++ b/src/config/dependencies/conf.d/templating.php
@@ -12,7 +12,7 @@ use Phpolar\PurePhp\TemplateEngine;
 
 
 return [
-    TemplateEngine::class => static fn () => new TemplateEngine(
+    TemplateEngine::class => new TemplateEngine(
         new StreamContentStrategy(),
         new Binder(),
         new Dispatcher(),


### PR DESCRIPTION
Some dependency injection libraries will create a new instance each time a dependency is requested if the dependency is registered using a function.  The dependencies that have been changed are stateless and typically used only once.